### PR TITLE
Add nitter as a better alternative to Twitter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -59,6 +59,11 @@ sidebar = "right" # Sidebar value ("left", "right" or false)
 # google tag manager, see https://developers.google.com/tag-manager/
 google_tag_manager = "GTM-5JNJ8NL" # example: G-XXXXXXXXXX
 
+# nitter
+nitter_instance = "https://nitter.pussthecat.org" # not all instances allow iframes
+nitter_default_user = "christitustech" # default user for tweet if none is defined
+nitter_theme = "twitter" # available: auto, auto_(twitter), black, dracula, mastodon, nitter, pleroma, twitter, twitter_dark
+
 code_copy_button = true # Turn on/off the code-copy-button for code-fields
 
 ######################## Site Variables #########################

--- a/content/posts/2022/best-package-manager.md
+++ b/content/posts/2022/best-package-manager.md
@@ -99,4 +99,4 @@ Basics of homebrew on Linux official documentation <https://docs.brew.sh/Homebre
 
 ## Thank you Homebrew Team
 
-{{< tweet user="christitustech" id="1554153066823385089" >}}
+{{< nitter user="christitustech" id="1554153066823385089" >}}

--- a/themes/northendlab/layouts/partials/style.html
+++ b/themes/northendlab/layouts/partials/style.html
@@ -45,4 +45,34 @@
     left: 10px;
     color: {{ with site.Params.variables }} {{.white}} {{ end }};
   }
+
+  .nitter-tweet {
+    display: flex;
+    max-width: 550px;
+    width: 100%;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+
+  .nitter-anchor, .nitter-widget {
+    display: block;
+    visibility: visible;
+    width: 550px;
+    height: 136px;
+    flex-grow: 1;
+    box-sizing: border-box;
+  }
+
+  .nitter-anchor {
+    position: absolute;
+    cursor: pointer;
+    z-index: 2;
+  }
+
+  .nitter-widget {
+    position: static;
+    border: 1px solid hsl(200, 19%, 84%);
+    border-radius: 12px;
+    z-index: 1;
+  }
 </style>

--- a/themes/northendlab/layouts/shortcodes/nitter.html
+++ b/themes/northendlab/layouts/shortcodes/nitter.html
@@ -1,0 +1,18 @@
+<div class="nitter-tweet nitter-tweet-rendered">
+    <a
+        class="nitter-anchor"
+        href="{{ site.Params.nitter_instance }}/{{ with .Get "user" }}{{ . }}{{ else }}{{ site.Params.nitter_default_user }}{{ end }}/status/{{ .Get "id" }}"
+        rel="noopener noreferrer nofollow"
+        target="_blank"
+        role="link"
+    ></a>
+    
+    <iframe
+        class="nitter-widget"
+        scrolling="no"
+        frameborder="0"
+        allowtransparency="true"
+        allowfullscreen="true"
+        src="{{ site.Params.nitter_instance }}/{{ with .Get "user" }}{{ . }}{{ else }}{{ site.Params.nitter_default_user }}{{ end }}/status/{{ .Get "id" }}/embed?theme={{ site.Params.nitter_theme }}"
+    ></iframe>
+</div>


### PR DESCRIPTION
Currently, the site uses Twitter embeds at the end of articles.
While tweets are a native feature in hugo, there is still some overhead from loading the original Twitter embed. The Twitter site uses big amounts of JavaScript for different processes, mostly telemetry, that have no positive impact for the user.
Even if the user doesn't necessarily care about his privacy, they will still experience longer load times from loading the embed - even more so on slower connections; perhaps on mobile - that may render the site barely usable.

Nitter is an open-source frontend for Twitter focused on providing a lightweight experience.