### PR TITLE
Replace google fonts with bunny fonts

### DIFF
--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -1,0 +1,72 @@
+<!-- font family -->
+<script src="https://cdn.jsdelivr.net/gh/theprojectsomething/webfontloader@feature/google-fonts-v2/webfontloader.js"></script>
+{{$pf:= site.Params.variables.primary_font}}
+{{$sf:= site.Params.variables.secondary_font}}
+<script>
+  WebFont.load({
+    google: {
+      api: 'https://fonts.bunny.net/css2',
+      families: ['{{$pf}}{{if not $sf}}&display=swap{{end}}'{{with $sf}},'{{.}}&display=swap'{{end}}],
+      version: 2
+    },
+    active: () => {
+      sessionStorage.fontsLoaded = true
+    }
+  });
+</script>
+
+<!-- JS Plugins + Main script -->
+{{ $scripts := slice }}
+{{ range site.Params.plugins.js}}
+{{ if findRE "^http" .link }}
+<script src="{{ .link | absURL }}" type="application/javascript" {{.attributes | safeHTMLAttr}}></script>
+{{ else }}
+{{ $scripts = $scripts | append (resources.Get .link) }}
+{{ end }}
+{{ end }}
+{{ $scripts := $scripts | append (resources.Get "js/script.js" | minify) }}
+{{ $scripts := $scripts | resources.Concat "/js/script.js" | minify | fingerprint "sha512" }}
+<script crossorigin="anonymous" defer="defer" data-turbolinks-suppress-warning integrity="{{ $scripts.Data.Integrity }}" type="application/javascript">{{$scripts.Content | safeJS}}</script>
+
+<!-- cookie -->
+{{ if site.Params.cookies.enable }}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
+<div id="js-cookie-box" class="cookie-box cookie-box-hide">
+  This site uses cookies. By continuing to use this website, you agree to their use. <span id="js-cookie-button" class="btn btn-sm btn-primary rounded ml-2">I Accept</span>
+</div>
+<script>
+  (function ($) {
+    const cookieBox = document.getElementById('js-cookie-box');
+    const cookieButton = document.getElementById('js-cookie-button');
+    if (!Cookies.get('cookie-box')) {
+      cookieBox.classList.remove('cookie-box-hide');
+      cookieButton.onclick = function () {
+        Cookies.set('cookie-box', true, {
+          expires: {{ site.Params.cookies.expire_days }}
+        });
+        cookieBox.classList.add('cookie-box-hide');
+      };
+    }
+  })(jQuery);
+</script>
+
+<!-- cookie style -->
+<style>
+.cookie-box {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  text-align: center;
+  z-index: 9999;
+  padding: 1rem 2rem;
+  background: #152035;
+  transition: all .75s cubic-bezier(.19, 1, .22, 1);
+  color: #fdfdfd;
+}
+
+.cookie-box-hide {
+  display: none;
+}
+</style>
+{{ end }}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -1,0 +1,101 @@
+<!-- plugins + stylesheet -->
+<link rel="preconnect" href="https://fonts.bunny.net">
+{{ $styles := slice }}
+{{ range site.Params.plugins.css }}
+{{ if findRE "^http" .link }}
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="{{ .link | absURL }}" {{.attributes | safeHTMLAttr}} >
+{{ else }}
+{{ $styles = $styles | append (resources.Get .link) }}
+{{ end }}
+{{ end }}
+{{ $styles := $styles | append (resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS) }}
+{{ $styles := $styles | resources.Concat "/css/style.css" | minify  | fingerprint "sha512"}}
+<style crossorigin="anonymous" media="all" type="text/css" integrity="{{ $styles.Data.Integrity }}">{{$styles.Content | safeCSS}}</style>
+
+<style>
+  /* Unordered Lists */
+  .content ul li:not(.nav-item) {
+    position: relative;
+    margin-bottom: 5px;
+    margin-left: 25px;
+    list-style-type: none;
+    font-size: 14px;
+  }
+  .content ul li:not(.nav-item)::before {
+    content: "";
+    position: absolute;
+    top: 1.2em;
+    left: -20px;
+    margin-top: -.9em;
+    background: linear-gradient(45deg, #9AC4F8, #7e7e7e);
+    height: 12px;
+    width: 12px;
+    border-radius: 50%;
+  }
+
+  ul li:not(.nav-item,.banner-social,.list-inline-item,.page-item) {
+    position: relative;
+    list-style-type: none;
+    font-size: 15px;
+  }
+  ul li:not(.nav-item,.banner-social,.list-inline-item,.page-item)::before {
+    content: "";
+    position: absolute;
+    top: 1.2em;
+    left: -15px;
+    margin-top: -.6em;
+    background: linear-gradient(45deg, #9AC4F8, #7e7e7e);
+    height: 8px;
+    width: 8px;
+    border-radius: 50%;
+  }
+
+  /* Ordered Lists */
+
+  .content ol li {
+    list-style-type: none;
+    counter-increment: item;
+    font-size: 14px;
+  }
+
+  .content ol li:before {
+    content: counter(item);
+    margin-right: 5px;
+    font-size: 80%;
+    background-color: #7e7e7e;
+    color: #7eb4e2;
+    font-weight: bold;
+    padding: 3px 8px;
+    border-radius: 3px;
+  }
+  .notices p::before {
+    position: absolute;
+    top: 2px;
+    font-family: "{{ with site.Params.variables }} {{.icon_font}} {{ end }}";
+    font-weight: 900;
+    content: "\f05a";
+    left: 10px;
+    display: none;
+  }
+  .notices p svg {
+    position: absolute;
+    top: 7px;
+    left: 10px;
+    color: {{ with site.Params.variables }} {{.white}} {{ end }};
+  }
+</style>
+
+  <!--Remove SVG list item
+  .content ul li:not(.nav-item) svg {
+    margin-right: 6px;
+    transform: scale(0.8);
+    color: {{ with site.Params.variables }} {{.primary_color}} {{ end }};
+  }
+  .content ul li:not(.nav-item)::before {
+    font-size: 14px;
+    font-family: "{{ with site.Params.variables }} {{.icon_font}} {{ end }}";
+    font-weight: 900;
+    content: "f0da";
+    display: none;
+  }
+  -->


### PR DESCRIPTION
I noticed your site is using Google Fonts. In my experience, they do have a habit of slowing things down and blocking requests, plus the extra tracking etc.

Bunny.net have their own fonts CDN that they claim doesn't do tracking, but I can definitely say that it's significantly faster.

Pretty simple patch, already tested and working.

I've attached 2 HARs, one for your current site, one for the updated code which shows the initial CSS request calling to half of its google load time, not to mention the font on top.

I'd have put the .har directly, but GitHub doesn't allow .har files....

[ctt-font-change-load-times.zip](https://github.com/ChrisTitusTech/website/files/10536997/ctt-font-change-load-times.zip)

