### PR TITLE
Remove duplicate head.html inclusion

### DIFF
--- a/themes/northendlab/layouts/_default/baseof.html
+++ b/themes/northendlab/layouts/_default/baseof.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="{{ with site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
-{{- partial "head.html" . -}}
 
 <head>
   {{ partial "head.html" . }}


### PR DESCRIPTION
Site was loading multiple sets of the same stuff due to head.html being included in both pre <head> and as a <head> member. This should only be loaded once ;).