### PR TITLE
Replace style include with link

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -10,7 +10,7 @@
 {{ end }}
 {{ $styles := $styles | append (resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS) }}
 {{ $styles := $styles | resources.Concat "/css/style.css" | minify  | fingerprint "sha512"}}
-<style crossorigin="anonymous" media="all" type="text/css" integrity="{{ $styles.Data.Integrity }}">{{$styles.Content | safeCSS}}</style>
+<link crossorigin="anonymous" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}" rel="preload stylesheet" as="style">
 
 <style>
   /* Unordered Lists */


### PR DESCRIPTION
Remove style and replace with a link to the generated file instead. Prevents transferring the styles every single page load.