### PR TITLE
Clean up dark theme

### DIFF
--- a/themes/northendlab/assets/scss/style.scss
+++ b/themes/northendlab/assets/scss/style.scss
@@ -25,7 +25,7 @@ $icon-font: '{{.icon_font}}';
 
 body.dark-mode, 
 body.dark-mode main * {
-    background: rgb(45, 45, 45);
+    background: #2d2d2d;
     color: #f5f5f5;
 }
 
@@ -68,7 +68,7 @@ body.dark-mode div.widget,
 body.dark-mode .card-block,
 body.dark-mode .col-md-6 *,
 body.dark-mode .bannerpad {
-    background: rgb(48, 48, 48) !important;
+    background: #2d2d2d !important;
 }
 
 body.dark-mode a {
@@ -136,4 +136,64 @@ h2.article-center {
 }
 .highlight-copy-btn:hover {
     background-color: #666;
+}
+
+body.dark-mode .pagination {
+    justify-content: center;
+  
+    .page-item {
+      margin: 0 2px;
+  
+      .page-link {
+        display: inline-block;
+        width: 40px;
+        height: 40px;
+        line-height: 26px;
+        text-align: center;
+        color: #d9d9d9;
+        background-color: #474747;
+        border: 0;
+        border-radius: 0;
+        font-weight: bold;
+  
+        &:hover {
+          background: $primary-color;
+          color: $white;
+          text-decoration: none;
+        }
+      }
+
+      &.active {
+        .page-link {
+          background: $primary-color;
+          color: $white;
+        }
+      }
+    }
+  }
+  
+// Remove this section to remove article background and decrease contrast
+body.dark-mode .block {
+    background-color: #3A3A3A;
+}
+
+// Remove this section to remove sidebar background and decrease contrast
+body.dark-mode div.widget {
+    background-color: #3A3A3A !important;
+}
+
+body.dark-mode .shadow {
+    box-shadow: none !important;
+}
+
+body.dark-mode .post-meta {
+    color: #999999;
+}
+
+body.dark-mode .card-block {
+    background-color: #3a3a3a !important;
+}
+
+body.dark-mode .card-block * {
+    background-color: inherit !important;
 }


### PR DESCRIPTION
- Changed main background and Twitch card to same background color (#2d2d2d)
- Changed article cards to use 5% brighter color than background
- Made pagination use a dark theme rather than light
- Increase background of article and sidebar by 5% to increase contrast
- Remove box shadow on dark mode
- Lighten post meta info to increase readability

**Before:**
![christitus com_ (1)](https://github.com/ChrisTitusTech/website/assets/78230669/a3ca2932-a574-4e08-8dfc-67b76f384a9d)
![christitus com_creating-a-secure-system_](https://github.com/ChrisTitusTech/website/assets/78230669/7b0004e3-420b-4144-b553-42af55867092)

**After:**
![localhost_1313_ (2)](https://github.com/ChrisTitusTech/website/assets/78230669/552773e7-fd36-4208-a1e9-73197a1a7702)
![localhost_1313_creating-a-secure-system_](https://github.com/ChrisTitusTech/website/assets/78230669/c922dcf7-3c91-442f-acc8-130e675dd623)
