### PR TITLE
Some style-related changes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -242,7 +242,7 @@ hasChildren = true
 [[menu.main]]
     weight = 7
     url = "https://youtube.com/@christitustech"
-    name = "Youtube"
+    name = "YouTube"
 
 ############################# Footer Menu ########################
 

--- a/themes/northendlab/assets/scss/_common.scss
+++ b/themes/northendlab/assets/scss/_common.scss
@@ -184,7 +184,7 @@ a.text-primary:hover {
 }
 
 .shadow {
-  box-shadow: 0 10px 30px 0 rgba(68,74,102,.1) !important;
+  box-shadow: rgba(0, 0, 0, 0.19) 0px 10px 20px, rgba(0, 0, 0, 0.23) 0px 6px 6px !important;
 }
 
 .form-control{

--- a/themes/northendlab/assets/scss/_common.scss
+++ b/themes/northendlab/assets/scss/_common.scss
@@ -184,7 +184,7 @@ a.text-primary:hover {
 }
 
 .shadow {
-  box-shadow: rgba(0, 0, 0, 0.19) 0px 10px 20px, rgba(0, 0, 0, 0.23) 0px 6px 6px !important;
+  box-shadow: rgba(0, 0, 0, 0.25) 0px 0.125em 0.5em, rgba(255, 255, 255, 0.1) 0px 0px 0px 1px inset !important;
 }
 
 .form-control{

--- a/themes/northendlab/assets/scss/templates/_main.scss
+++ b/themes/northendlab/assets/scss/templates/_main.scss
@@ -228,7 +228,7 @@
       font-weight: bold;
 
       &:hover {
-        background: $primary-color;
+        background: $text-color;
         color: $white;
       }
     }
@@ -244,9 +244,19 @@
 
 .post-title {
   color: $black;
+  font-weight: bold;
+
   &:hover {
     text-decoration: underline;
   }
+}
+
+.post-category {
+  font-style: italic;
+}
+
+.post-category:not(:last-of-type)::after {
+  content: ", ";
 }
 
 .post-meta {

--- a/themes/northendlab/assets/scss/templates/_main.scss
+++ b/themes/northendlab/assets/scss/templates/_main.scss
@@ -253,10 +253,10 @@
 
 .post-category {
   font-style: italic;
-}
 
-.post-category:not(:last-of-type)::after {
-  content: ", ";
+  &:not(:last-of-type)::after {
+    content: ", ";
+  }
 }
 
 .post-meta {

--- a/themes/northendlab/layouts/_default/article-w-image.html
+++ b/themes/northendlab/layouts/_default/article-w-image.html
@@ -2,7 +2,7 @@
   {{ if .Params.image }}
   <div class="col-md-6">
     <!--a href="{{ .Permalink }}"><img loading="lazy" class="w-100" src="{{ .Params.image | absURL }}" alt="post-image"></a-->
-    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" width="300"></a>
+    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" width="300" class="rounded shadow"></a>
   </div>
   {{ end }}
   <div class="col-md-6">

--- a/themes/northendlab/layouts/_default/article-w-image.html
+++ b/themes/northendlab/layouts/_default/article-w-image.html
@@ -2,7 +2,7 @@
   {{ if .Params.image }}
   <div class="col-md-6">
     <!--a href="{{ .Permalink }}"><img loading="lazy" class="w-100" src="{{ .Params.image | absURL }}" alt="post-image"></a-->
-    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" class="" width="300"></a>
+    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" width="300"></a>
   </div>
   {{ end }}
   <div class="col-md-6">

--- a/themes/northendlab/layouts/_default/article-w-image.html
+++ b/themes/northendlab/layouts/_default/article-w-image.html
@@ -2,7 +2,7 @@
   {{ if .Params.image }}
   <div class="col-md-6">
     <!--a href="{{ .Permalink }}"><img loading="lazy" class="w-100" src="{{ .Params.image | absURL }}" alt="post-image"></a-->
-    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" class="rounded shadow" width="300"></a>
+    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" class="" width="300"></a>
   </div>
   {{ end }}
   <div class="col-md-6">
@@ -10,8 +10,12 @@
       <h2 class="h4"><a class="post-title" href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
       <p>{{.Summary | truncate 100}}</p>
       <div class="mt-3 post-meta">
-        {{ .PublishDate.Format "Jan 2, 2006" }} <span class="mx-1">|</span> {{ range .Params.Categories }}
-        <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+        {{ .PublishDate.Format "Jan 2, 2006" }}
+        {{ if .Params.Categories }}
+          <span class="mx-1">|</span>
+          {{ range .Params.Categories }}
+          <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+          {{ end }}
         {{ end }}
       </div>
     </div>

--- a/themes/northendlab/layouts/_default/article-w-image.html
+++ b/themes/northendlab/layouts/_default/article-w-image.html
@@ -2,7 +2,7 @@
   {{ if .Params.image }}
   <div class="col-md-6">
     <!--a href="{{ .Permalink }}"><img loading="lazy" class="w-100" src="{{ .Params.image | absURL }}" alt="post-image"></a-->
-    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" width="300"></a>
+    <a href="{{ .Permalink }}"><img src="{{ .Params.image | absURL }}" class="rounded shadow" width="300"></a>
   </div>
   {{ end }}
   <div class="col-md-6">
@@ -10,9 +10,8 @@
       <h2 class="h4"><a class="post-title" href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
       <p>{{.Summary | truncate 100}}</p>
       <div class="mt-3 post-meta">
-        <a href="{{ `author/` | absLangURL }}{{ .Params.Author | urlize | lower }}">{{ .Params.Author | title }}</a> <span class="mx-1">|</span>
         {{ .PublishDate.Format "Jan 2, 2006" }} <span class="mx-1">|</span> {{ range .Params.Categories }}
-        <a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a>
+        <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
         {{ end }}
       </div>
     </div>

--- a/themes/northendlab/layouts/_default/article.html
+++ b/themes/northendlab/layouts/_default/article.html
@@ -1,8 +1,12 @@
 <article class="mb-4 pb-2">
   <h2 class="h4"><a class="post-title" href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
   <div class="mb-3 post-meta">
-    {{ .PublishDate.Format "Jan 2, 2006" }} <span class="mx-1">|</span> {{ range .Params.Categories }}
-    <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+    {{ .PublishDate.Format "Jan 2, 2006" }}
+    {{ if .Params.Categories }}
+      <span class="mx-1">|</span>
+      {{ range .Params.Categories }}
+      <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+      {{ end }}
     {{ end }}
   </div>
   <p>{{.Summary}}</p>

--- a/themes/northendlab/layouts/_default/article.html
+++ b/themes/northendlab/layouts/_default/article.html
@@ -1,9 +1,8 @@
 <article class="mb-4 pb-2">
   <h2 class="h4"><a class="post-title" href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
   <div class="mb-3 post-meta">
-    <a href="{{ `author/` | absLangURL }}{{ .Params.Author | urlize | lower }}">{{ .Params.Author | title }}</a> <span class="mx-1">|</span>
     {{ .PublishDate.Format "Jan 2, 2006" }} <span class="mx-1">|</span> {{ range .Params.Categories }}
-    <a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a>
+    <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
     {{ end }}
   </div>
   <p>{{.Summary}}</p>

--- a/themes/northendlab/layouts/_default/single.html
+++ b/themes/northendlab/layouts/_default/single.html
@@ -24,9 +24,8 @@
         <div class="block shadow mb-4">
           <h2>{{ .Title | markdownify }}</h2>
           <div class="mb-4 mt-3 post-meta">
-            <a href="{{ `author/` | absLangURL }}{{ .Params.Author | urlize | lower }}">{{ .Params.Author | title }}</a> <span class="mx-2">|</span>
             {{ .PublishDate.Format "Jan 2, 2006" }}<span class="mx-2">|</span> {{ range .Params.Categories }}
-            <a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a>
+            <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
             {{ end }}
           </div>
           {{ if .Params.Image }}
@@ -42,8 +41,9 @@
           </div>
         </div>
 
+        {{ $related := site.RegularPages.Related . | first 5 }}
+        {{ if $related }}
         <div class="block shadow">
-          {{ $related := site.RegularPages.Related . | first 5 }}
           {{ with $related }}
           <h3 class="mb-3">See Also</h3>
           <ul class="list-unstyled related-post-list">
@@ -53,6 +53,7 @@
           </ul>
           {{ end }}
         </div>
+        {{ end }}
         <!-- Github Comments addition -->
         <script src="https://utteranc.es/client.js"
           repo="ChrisTitusTech/website"

--- a/themes/northendlab/layouts/_default/single.html
+++ b/themes/northendlab/layouts/_default/single.html
@@ -24,8 +24,12 @@
         <div class="block shadow mb-4">
           <h2>{{ .Title | markdownify }}</h2>
           <div class="mb-4 mt-3 post-meta">
-            {{ .PublishDate.Format "Jan 2, 2006" }}<span class="mx-2">|</span> {{ range .Params.Categories }}
-            <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+            {{ .PublishDate.Format "Jan 2, 2006" }}
+            {{ if .Params.Categories }}
+              <span class="mx-1">|</span>
+              {{ range .Params.Categories }}
+              <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+              {{ end }}
             {{ end }}
           </div>
           {{ if .Params.Image }}

--- a/themes/northendlab/layouts/homepage/single.html
+++ b/themes/northendlab/layouts/homepage/single.html
@@ -100,8 +100,12 @@
             <div class="card-block">
               <h2 class="h4 mb-4"><a class="post-title" href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
               <div class="mb-3 post-meta">
-                {{ .PublishDate.Format "Jan 2, 2006" }} <span class="mx-1">|</span> {{ range .Params.Categories }}
-                <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+                {{ .PublishDate.Format "Jan 2, 2006" }}
+                {{ if .Params.Categories }}
+                  <span class="mx-1">|</span>
+                  {{ range .Params.Categories }}
+                  <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
+                  {{ end }}
                 {{ end }}
               </div>
             </div>

--- a/themes/northendlab/layouts/homepage/single.html
+++ b/themes/northendlab/layouts/homepage/single.html
@@ -100,9 +100,8 @@
             <div class="card-block">
               <h2 class="h4 mb-4"><a class="post-title" href="{{ .Permalink }}">{{ .Title | markdownify }}</a></h2>
               <div class="mb-3 post-meta">
-                <a href="{{ `author/` | absLangURL }}{{ .Params.Author | urlize | lower }}">{{ .Params.Author | title }}</a> <span class="mx-1">|</span>
                 {{ .PublishDate.Format "Jan 2, 2006" }} <span class="mx-1">|</span> {{ range .Params.Categories }}
-                <a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a>
+                <span class="post-category"><a href="{{ `categories/` | absLangURL }}{{ . | urlize | lower }}">{{ . | title }}</a></span>
                 {{ end }}
               </div>
             </div>

--- a/themes/northendlab/layouts/partials/header.html
+++ b/themes/northendlab/layouts/partials/header.html
@@ -82,7 +82,7 @@
             <form action="{{ `search` | absLangURL }}" class="w-100">
               <input class="search-box" id="search-query" name="s" type="search" placeholder="{{ i18n `search_placeholder` }}" required>
             </form>
-            <button class="search-btn pl-0 "><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/></svg></button>
+            <button class="search-btn pl-0 "><i class="fa fa-search"></i></button>
           </div>
         </div>
         {{ else if eq $search_layout "popupable" }}
@@ -91,7 +91,7 @@
           <div class="search-wrapper">
             <form action="{{ `search` | absLangURL }}" class="h-100">
               <input class="search-box px-4" id="search-query" name="s" type="search" placeholder="{{ i18n `search_placeholder` }}" required>
-              <button type="button" id="searchClose" class="search-close"><svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" viewBox="0 0 16 16"><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/></svg></button>
+              <button type="button" id="searchClose" class="search-close"><i class="fa fa-search"></i></button>
             </form>
           </div>
         </div>

--- a/themes/northendlab/layouts/partials/header.html
+++ b/themes/northendlab/layouts/partials/header.html
@@ -91,7 +91,7 @@
           <div class="search-wrapper">
             <form action="{{ `search` | absLangURL }}" class="h-100">
               <input class="search-box px-4" id="search-query" name="s" type="search" placeholder="{{ i18n `search_placeholder` }}" required>
-              <button type="button" id="searchClose" class="search-close"><i class="fa fa-search"></i></button>
+              <button type="button" id="searchClose" class="search-close"><svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" fill="currentColor" viewBox="0 0 16 16"><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/></svg></button>
             </form>
           </div>
         </div>

--- a/themes/northendlab/layouts/partials/widgets/featured-post.html
+++ b/themes/northendlab/layouts/partials/widgets/featured-post.html
@@ -11,7 +11,7 @@
       <div class="ml-3">
         <h6 class="mb-1"><a class="post-title" href="{{.Permalink}}">{{ .Title }}</a></h6>
         <div class="post-meta small">
-          <a href="{{ `author/` | absLangURL }}{{ .Params.Author | urlize | lower }}">{{ .Params.Author | title }}</a> <span class="mx-1">|</span> {{ .PublishDate.Format "Jan 2, 2006" }}
+          {{ .PublishDate.Format "Jan 2, 2006" }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Changes:
- Improved the `box-shadow` for the `.shadow` class that is used (https://getcssscan.com/css-box-shadow-examples)
- Added a comma delimiter for the post categories - as range is used to loop through the categories, you can't easily use Hugo's `delimit` function; I used a CSS rule.
- Removed the unused author name from articles as it added an extra '|' character before the date previously + same functionality for articles without categories
- Made it so the related posts block only shows if their are related posts to show to begin with
- Rounded the thumbnail images for featured articles
- Made article titles bold - I think it improves the UI
- Converted SVG search icon to FontAwesome

Here's a preview I've attached below:

https://i.imgur.com/5B6eVk7.png