### PR TITLE
Responsive homepage changes for mobile and tablet

### DIFF
--- a/themes/northendlab/assets/scss/_common.scss
+++ b/themes/northendlab/assets/scss/_common.scss
@@ -208,6 +208,7 @@ textarea.form-control{
 .widget {
   margin-bottom: 30px;
   padding: 20px 30px;
+  border-radius: 4px;
   @extend .shadow;
 }
 

--- a/themes/northendlab/assets/scss/_mixins.scss
+++ b/themes/northendlab/assets/scss/_mixins.scss
@@ -29,6 +29,25 @@
   }
 }
 
+// https://stackoverflow.com/a/67297049
+@mixin media($keys...) {
+  @each $key in $keys {
+    @if ($key == phone) {
+      @include phone {
+        @content
+      }
+    } @else if ($key == tablet) {
+      @include tablet {
+        @content
+      }
+    } @else if ($key == desktop) {
+      @include desktop {
+        @content
+      }
+    }
+  }
+}
+
 @mixin size($size){
   width: $size; height: $size;
 }

--- a/themes/northendlab/assets/scss/_mixins.scss
+++ b/themes/northendlab/assets/scss/_mixins.scss
@@ -32,8 +32,12 @@
 // https://stackoverflow.com/a/67297049
 @mixin media($keys...) {
   @each $key in $keys {
-    @if ($key == phone) {
-      @include phone {
+    @if ($key == mobile-xs) {
+      @include mobile-xs {
+        @content
+      }
+    } @else if ($key == mobile) {
+      @include mobile {
         @content
       }
     } @else if ($key == tablet) {
@@ -42,6 +46,14 @@
       }
     } @else if ($key == desktop) {
       @include desktop {
+        @content
+      }
+    } @else if ($key == desktop-lg) {
+      @include desktop-lg {
+        @content
+      }
+    } @else if ($key == desktop-xl) {
+      @include desktop-xl {
         @content
       }
     }

--- a/themes/northendlab/assets/scss/templates/_main.scss
+++ b/themes/northendlab/assets/scss/templates/_main.scss
@@ -83,6 +83,7 @@
     padding: 30px;
     margin-left: -60px;
     background: $white;
+    border-radius: 4px;
     @include desktop {
       margin-left: 0;
       padding: 15px;
@@ -216,6 +217,7 @@
 /* blog */
 .block {
   padding: 40px;
+  border-radius: 4px;
 }
 
 .author-thumb {

--- a/themes/northendlab/assets/scss/templates/_main.scss
+++ b/themes/northendlab/assets/scss/templates/_main.scss
@@ -71,15 +71,30 @@
 
 // article-overlapped-list
 .article-overlapped-list {
+  img {
+    @include media(mobile, tablet) {
+      margin-left: auto;
+      margin-right: auto;
+      display: block;
+    }
+  }
+
   .card-block {
     padding: 30px;
     margin-left: -60px;
     background: $white;
     @include desktop {
       margin-left: 0;
-      padding: 0;
+      padding: 15px;
+    }
+
+    @include media(tablet, mobile) {
+      padding: 15px;
+      margin-top: 15px;
+      text-align: center;
     }
   }
+
   @include tablet {
     img.w-100 {
       margin-bottom: 20px;

--- a/themes/northendlab/assets/scss/templates/_main.scss
+++ b/themes/northendlab/assets/scss/templates/_main.scss
@@ -89,7 +89,7 @@
       padding: 15px;
     }
 
-    @include media(tablet, mobile) {
+    @include media(mobile, tablet) {
       padding: 15px;
       margin-top: 15px;
       text-align: center;


### PR DESCRIPTION
This PR focuses on improving the responsiveness of the homepage on mobile and tablet devices. It seems like things weren't being resized/padded properly before, these changes seem to help a bit:

- Article content on homepage is centered on small devices
- Padding added to the description cards
- Margin (spacing) applied also

Within this PR I have also decided to add a border radius of 4 pixels to cards/blocks as I believe this makes the site look more modern, let me know your thoughts if you disagree.

GIF attached.
 
![poc](https://github.com/ChrisTitusTech/website/assets/107592590/7dcae9bc-7356-428b-ba71-61e9b55922ac)
