### PR TITLE
Update Universal Android Debloater Link

### DIFF
--- a/content/posts/2022/making-the-perfect-phone.md
+++ b/content/posts/2022/making-the-perfect-phone.md
@@ -81,7 +81,7 @@ From your command line interface (terminal, powershell, etc.) type `adb devices`
 
 Verify your phone is seen
 
-Now download the release from their GitHub <https://github.com/0x192/universal-android-debloater/releases>
+Now download the release from their GitHub <https://github.com/Universal-Debloater-Alliance/universal-android-debloater-next-generation/releases>
 
 Then launch the program
 


### PR DESCRIPTION
Update Universal Android Debloater link to a maintained version of the project as the original project is largely abandoned and outdated.