### PR TITLE
change to smaller thumbnails for the live stream tab

### DIFF
--- a/scripts/fetch-livestreams.py
+++ b/scripts/fetch-livestreams.py
@@ -67,11 +67,9 @@ def fetch_playlist_items() -> list:
 
             thumbnails = snippet.get("thumbnails", {})
             thumbnail = (
-                thumbnails.get("maxres", {}).get("url")
-                or thumbnails.get("high", {}).get("url")
-                or thumbnails.get("medium", {}).get("url")
+                thumbnails.get("medium", {}).get("url")
                 or thumbnails.get("default", {}).get("url")
-                or f"https://i.ytimg.com/vi/{video_id}/hqdefault.jpg"
+                or f"https://i.ytimg.com/vi/{video_id}/mqdefault.jpg"
             )
 
             description = snippet.get("description", "").strip()


### PR DESCRIPTION
every thumbnail listed seems to be the highest resolution, but it doesn't need to be

from a sample of 16 thumbnails, they amount to around 2MBs. I don't know how much the total of 100+ thumbnails would amount to, but I assume it'll be many more MBs

I changed to the medium size, the 16 thumbnails now amount to around 160kB