### PR TITLE
Add forums link to the navbar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -113,7 +113,7 @@ weight = 4
 url = "newsletter/"
 name = "Newsletter"
 [[menu.main]]
-weight = 6
+weight = 5
 url = "#"
 name = "Sections"
 hasChildren = true
@@ -138,9 +138,13 @@ name = "Windows"
 url = "/categories/windows"
 parent = "Sections"
 [[menu.main]]
-weight = 7
+weight = 6
 url = "https://youtube.com/@christitustech"
 name = "YouTube"
+[[menu.main]]
+weight = 7
+url = "https://forum.christitus.com"
+name = "Forums"
 
 [[menu.footer]]
 weight = 3


### PR DESCRIPTION
updated the main menu configuration in `config.toml` to adjust the ordering and add a new menu item. The most notable changes are the reordering of existing menu items and the introduction of a "Forums" link.

Menu updates:

- Adjusted the `weight` values for the "Sections" and "YouTube" menu items to update their display order in the main menu.
- Added a new "Forums" menu item to the main menu, linking to `https://forum.christitus.com`.