### PR TITLE
added docker for security

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.astro
+dist
+.git
+.env
+.env.*
+*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@
 - Preserve unrelated worktree changes and inspect `git status --short` before
   editing.
 - Do not expose secrets, tokens, private keys, sessions, or environment files.
+- Never run `npm`, `npx`, `pnpm`, or `yarn` directly on the host, under no
+  circumstances and with no exceptions — not even "just to check something"
+  or for a single quick command. All such commands must go through the
+  Docker Compose service described in Toolchain.
 
 ## Project overview
 
@@ -26,10 +30,39 @@
 
 ## Toolchain
 
-- The runtime is Node.js 24 with npm and a committed lockfile. Install with
-  `npm ci`, develop with `npm run dev`, run focused checks with
-  `npm run check` and `npm test`, build with `npm run build`, and use
-  `npm run validate` as the complete local gate.
+- The runtime is Node.js 24 (`package.json` `engines` requires `>=24 <25`;
+  the `Dockerfile` base image is pinned to match) with npm and a committed
+  lockfile.
+- All npm installs, scripts, and dev servers run inside Docker via
+  `docker-compose.yml`. Invoking `npm`/`npx`/`pnpm`/`yarn` directly on the
+  host is forbidden under all circumstances, no exceptions — see Command
+  execution. The compose service is `christitus-website`.
+  - Install/update deps: `docker compose run --rm christitus-website npm ci`
+    (or `npm install <pkg>` after editing `package.json`)
+  - Dev server: `docker compose up christitus-website` (serves on
+    `127.0.0.1:4321`, host code changes are reflected via the bind mount)
+  - Checks/tests: `docker compose run --rm christitus-website npm run check`
+    and `npm test`
+  - Build: `docker compose run --rm christitus-website npm run build`
+  - Full local gate: `docker compose run --rm christitus-website npm run validate`
+  - After changing `package.json`/`package-lock.json`, rebuild the image:
+    `docker compose build christitus-website`
+  - `node_modules` is a named volume and is not written back to the host tree.
+- On Windows hosts, Docker Desktop's WSL2 backend bridges the bind-mounted
+  project directory over the 9P protocol, which is slow for high-frequency
+  filesystem polling. Dev-server startup takes roughly 15-30s on such hosts;
+  this is expected and not a hang. Related mitigations, do not remove without
+  re-verifying dev-server startup and both live-edit paths on a Windows/WSL2
+  host:
+  - `astro.config.mjs` configures Vite's watcher to poll (native inotify does
+    not see host-side edits over this bridge) at a longer interval than
+    default and excludes `static/` and `content/` from that scope.
+  - `content/` is instead watched by a dedicated `chokidar` poller in
+    `scripts/dev.mjs` that regenerates `.astro-content/`, which Astro's
+    content collections load from.
+  - `docker-compose.yml` raises `UV_THREADPOOL_SIZE` because Astro's startup
+    I/O and both pollers otherwise contend for libuv's default 4 worker
+    threads, which can stall dev-server startup indefinitely.
 - Astro production output is `dist/`; `.astro/` is generated type and
   content metadata. Never edit or commit either directory as source.
 
@@ -61,8 +94,8 @@
   `featuredOrder` are optional. An omitted `draft` value means published;
   production excludes only `draft: true`.
 - Once the Phase 2 Astro foundation lands, create posts with
-  `npm run new:post -- "<title>" [--date YYYY-MM-DD] [--category "<name>" ...]`.
-  The repository-owned scaffolder renders `templates/post.md.tmpl` into
+  `docker compose run --rm christitus-website npm run new:post -- "<title>" [--date YYYY-MM-DD] [--category "<name>" ...]`
+  (see Toolchain). The repository-owned scaffolder renders `templates/post.md.tmpl` into
   `content/posts/<year>/<slug>.md`, defaults new posts to drafts, uses the
   current `America/Chicago` calendar date when `--date` is absent, and refuses
   to overwrite files. It serializes titles as JSON-compatible double-quoted
@@ -188,8 +221,9 @@
 
 - Make small reviewable commits even though the migration is delivered in one
   pull request.
-- Validate focused behavior while implementing and run `npm run validate` as
-  the complete gate.
+- Validate focused behavior while implementing and run
+  `docker compose run --rm christitus-website npm run validate` as
+  the complete gate (see Toolchain).
 - For content changes, verify schema parsing, draft and future-date exclusion,
   and production rendering.
 - For route or metadata changes, compare the generated route contract and

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:24-bookworm-slim
+
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+RUN chown -R node:node /app
+USER node
+
+EXPOSE 4321
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,4 +22,13 @@ export default defineConfig({
       destination: "https://youtube.com/@christitustech",
     },
   },
+  vite: {
+    server: {
+      watch: {
+        usePolling: true,
+        interval: 1000,
+        ignored: ["**/static/**", "**/content/**"],
+      },
+    },
+  },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  christitus-website:
+    build: .
+    container_name: christitus-website
+    working_dir: /app
+    ports:
+      - "127.0.0.1:4321:4321"
+    volumes:
+      - .:/app
+      - astro_node_modules:/app/node_modules
+    environment:
+      - ASTRO_TELEMETRY_DISABLED=1
+      - UV_THREADPOOL_SIZE=32
+
+volumes:
+  astro_node_modules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/markdown-it": "14.1.2",
         "@types/node": "26.2.0",
         "@types/sanitize-html": "2.16.1",
+        "chokidar": "4.0.3",
         "markdownlint-cli2": "0.23.2",
         "prettier": "3.9.6",
         "prettier-plugin-astro": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/markdown-it": "14.1.2",
     "@types/node": "26.2.0",
     "@types/sanitize-html": "2.16.1",
+    "chokidar": "4.0.3",
     "markdownlint-cli2": "0.23.2",
     "prettier": "3.9.6",
     "prettier-plugin-astro": "0.14.1",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { watch } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { spawn } from "node:child_process";
+
+import chokidar from "chokidar";
 
 import { prepareContent } from "./prepare-content.mjs";
 
@@ -54,15 +55,16 @@ async function refreshContent() {
   }
 }
 
-const watcher = watch(
-  path.join(root, "content"),
-  { recursive: true },
-  (_event, filename) => {
-    if (!filename?.endsWith(".md")) return;
-    clearTimeout(timer);
-    timer = setTimeout(() => void refreshContent(), 100);
-  },
-);
+const watcher = chokidar.watch(path.join(root, "content"), {
+  ignoreInitial: true,
+  usePolling: true,
+  interval: 1000,
+});
+watcher.on("all", (_event, filename) => {
+  if (!filename?.endsWith(".md")) return;
+  clearTimeout(timer);
+  timer = setTimeout(() => void refreshContent(), 100);
+});
 
 function stop(signal) {
   if (stopping) return;


### PR DESCRIPTION
This pull request introduces a Docker-based development workflow for the project. The primary motivation is security: with the current wave of npm supply-chain attacks (malicious postinstall/preinstall scripts, credential-stealing packages published under typosquatted or hijacked package names), running npm/npx/pnpm/yarn directly on a developer's host is a real attack surface — any of those commands can execute arbitrary code with the developer's full user permissions, with access to SSH keys, browser credential stores, and other local secrets. Containerizing all Node.js execution confines that risk to a disposable, isolated environment with no access to the host beyond the project directory itself.

Secondarily, this also improves cross-platform consistency (no more "works on my machine" Node version drift) and, on Windows specifically, required tuning the dev server's file-watching to work reliably under Docker Desktop's WSL2 filesystem bridge.

**Dockerization and Toolchain Enforcement**

* Added a `Dockerfile` based on `node:24-bookworm-slim` to define the Node.js environment and entrypoint for the development server.
* Introduced a `docker-compose.yml` file to manage the development container, bind mount the project directory, and use a named volume for `node_modules` to prevent host contamination.
* Updated `.dockerignore` to exclude development artifacts and sensitive files from Docker context.

**Documentation Updates**

* Revised `AGENTS.md` to require that all npm/yarn/pnpm commands run exclusively inside the Docker Compose service, with explicit instructions for development, testing, building, and post-install steps. Host execution of these commands is now strictly forbidden. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R12-R15) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L29-R65) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L64-R98) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L191-R226)

**Development Experience and Cross-Platform Support**

* Updated `astro.config.mjs` to configure Vite's watcher for polling with a longer interval and to ignore certain directories, improving compatibility and performance on Windows/WSL2 hosts.
* Enhanced `scripts/dev.mjs` by replacing Node's native `fs.watch` with `chokidar` for more reliable and configurable polling of the `content/` directory, ensuring content updates are detected across platforms. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R54) [[2]](diffhunk://#diff-0559901a4c3b5be9b8257debd3cd795b0424df2de22427404d0c1c82beb8311bL3-R8) [[3]](diffhunk://#diff-0559901a4c3b5be9b8257debd3cd795b0424df2de22427404d0c1c82beb8311bL57-R67)