### PR TITLE
Retry transient livestream API failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,17 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  automation-tests:
+    name: Automation tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check --require-hashes --requirement scripts/requirements-automation.txt
+      - run: python -m unittest discover -s tests/python -p "test_*.py" -v
+
   build-route-validation:
     name: Build and route validation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Astro site and deployed with Cloudflare Pages.
 
 - Node.js 24
 - npm
+- Python 3.12
 
 Install the exact dependency tree and run the complete local gate:
 
 ```bash
 npm ci
+python -m pip install --disable-pip-version-check --require-hashes --requirement scripts/requirements-automation.txt
 npm run validate
 ```
 

--- a/docs/automation/livestream-data.md
+++ b/docs/automation/livestream-data.md
@@ -28,6 +28,14 @@ the hash-locked `scripts/requirements-automation.txt`. Existing secret names and
 data contracts are unchanged: `YOUTUBE_API_KEY`, `TWITCH_CLIENT_ID`, and
 `TWITCH_CLIENT_SECRET`.
 
+YouTube and Twitch API calls share a bounded retry policy for connection and
+read failures plus HTTP 408, 429, and transient 5xx responses. The policy uses
+exponential backoff, honors `Retry-After` up to 60 seconds, and does not retry
+permanent 4xx responses. The YouTube API key is sent in the `X-Goog-Api-Key`
+header so failures cannot expose it in a request URL. Run the regression suite
+with `npm run test:automation` after installing the hash-locked Python
+requirements.
+
 All retained-workflow jobs use the protected `livestream-data-automation`
 environment, and the entry job requires the workflow to run from `master`. The
 three data credentials are scoped to that environment, whose deployment policy

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "CONTENT_PREVIEW=0 npm run prepare:content && CONTENT_PREVIEW=0 astro build",
     "preview": "astro preview",
     "test": "CONTENT_PREVIEW=0 npm run prepare:content && vitest run",
+    "test:automation": "python -m unittest discover -s tests/python -p \"test_*.py\" -v",
     "test:watch": "vitest",
     "validate:routes": "node scripts/validate-routes.mjs",
     "validate:repeat": "node scripts/validate-repeatability.mjs",
@@ -28,7 +29,7 @@
     "format:check": "prettier --check . --ignore-path .prettierignore",
     "lint:markdown": "markdownlint-cli2 README.md SPEC.md 'docs/**/*.md' 'templates/**/*.md'",
     "audit": "node scripts/audit.mjs",
-    "validate:core": "npm run format:check && npm run lint:markdown && npm run audit && npm run check && npm run test && npm run build && npm run validate:repeat && npm run validate:routes",
+    "validate:core": "npm run format:check && npm run lint:markdown && npm run audit && npm run check && npm run test && npm run test:automation && npm run build && npm run validate:repeat && npm run validate:routes",
     "validate": "npm run setup:browsers && npm run validate:core && npm run test:browser && npm run test:browser:webkit && npm run test:lighthouse",
     "new:post": "node scripts/new-post.mjs"
   },

--- a/scripts/download-chat-replays.py
+++ b/scripts/download-chat-replays.py
@@ -12,10 +12,13 @@ from pathlib import Path
 
 import requests
 
+from http_client import create_retry_session
+
 
 DATA_PATH = Path("data/livestreams.json")
 CHAT_DIR = Path("public/chats")
 DOWNLOADER = Path(__file__).resolve().parent.parent / "TwitchDownloaderCLI"
+HTTP = create_retry_session()
 
 
 def parse_iso(value: str) -> datetime:
@@ -27,7 +30,7 @@ def current_live_vod(data: dict, client_id: str, client_secret: str) -> str | No
         return None
     channel = os.environ.get("TWITCH_CHANNEL", "christitustech")
     try:
-        token_response = requests.post(
+        token_response = HTTP.post(
             "https://id.twitch.tv/oauth2/token",
             data={
                 "client_id": client_id,
@@ -41,7 +44,7 @@ def current_live_vod(data: dict, client_id: str, client_secret: str) -> str | No
             "Authorization": f"Bearer {token_response.json()['access_token']}",
             "Client-Id": client_id,
         }
-        stream_response = requests.get(
+        stream_response = HTTP.get(
             "https://api.twitch.tv/helix/streams",
             params={"user_login": channel},
             headers=headers,
@@ -58,7 +61,7 @@ def current_live_vod(data: dict, client_id: str, client_secret: str) -> str | No
             video_id = item.get("videoId")
             if not vod_id or not video_id or (CHAT_DIR / f"{video_id}.json").exists():
                 continue
-            video_response = requests.get(
+            video_response = HTTP.get(
                 "https://api.twitch.tv/helix/videos",
                 params={"id": vod_id},
                 headers=headers,

--- a/scripts/fetch-livestreams.py
+++ b/scripts/fetch-livestreams.py
@@ -13,13 +13,14 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-import requests
+from http_client import create_retry_session
 
 API_KEY = os.environ.get("YOUTUBE_API_KEY", "")
 PLAYLIST_ID = os.environ.get("PLAYLIST_ID", "PLc7fktTRMBow1ksFW020hx2XEKabaD5Vd")
 OUTPUT_FILE = Path(__file__).parent.parent / "data" / "livestreams.json"
 CHATS_DIR   = Path(__file__).parent.parent / "public" / "chats"
 BASE_URL = "https://www.googleapis.com/youtube/v3/playlistItems"
+HTTP = create_retry_session()
 
 
 def fetch_playlist_items() -> list:
@@ -31,15 +32,21 @@ def fetch_playlist_items() -> list:
             "part": "snippet",
             "playlistId": PLAYLIST_ID,
             "maxResults": 50,
-            "key": API_KEY,
         }
         if next_page_token:
             params["pageToken"] = next_page_token
 
-        resp = requests.get(BASE_URL, params=params, timeout=30)
+        resp = HTTP.get(
+            BASE_URL,
+            params=params,
+            headers={"X-Goog-Api-Key": API_KEY},
+            timeout=30,
+        )
         if resp.status_code == 403:
-            print(f"Error 403: Check that your YOUTUBE_API_KEY is valid and the "
-                  f"YouTube Data API v3 is enabled.", file=sys.stderr)
+            print(
+                "Error 403: Check the YouTube API credential, API access, and quota.",
+                file=sys.stderr,
+            )
             sys.exit(1)
         resp.raise_for_status()
         data = resp.json()

--- a/scripts/http_client.py
+++ b/scripts/http_client.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Shared, bounded HTTP retry policy for livestream automation."""
+
+from __future__ import annotations
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+
+RETRY_COUNT = 4
+# The only current POST calls mint Twitch app tokens and are safe to repeat.
+RETRYABLE_METHODS = frozenset({"GET", "POST"})
+RETRYABLE_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504})
+
+
+def build_retry_policy() -> Retry:
+    """Return the bounded retry policy used by trusted automation APIs."""
+    return Retry(
+        total=RETRY_COUNT,
+        connect=RETRY_COUNT,
+        read=RETRY_COUNT,
+        status=RETRY_COUNT,
+        other=0,
+        allowed_methods=RETRYABLE_METHODS,
+        status_forcelist=RETRYABLE_STATUS_CODES,
+        backoff_factor=1.0,
+        backoff_max=30.0,
+        backoff_jitter=0.5,
+        respect_retry_after_header=True,
+        retry_after_max=60,
+        raise_on_status=False,
+    )
+
+
+def create_retry_session() -> requests.Session:
+    """Create a session that retries transient API failures and nothing else."""
+    session = requests.Session()
+    adapter = HTTPAdapter(max_retries=build_retry_policy())
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/scripts/match-twitch-vods.py
+++ b/scripts/match-twitch-vods.py
@@ -17,12 +17,13 @@ import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
-import requests
+from http_client import create_retry_session
 
 CLIENT_ID     = os.environ.get("TWITCH_CLIENT_ID", "")
 CLIENT_SECRET = os.environ.get("TWITCH_CLIENT_SECRET", "")
 CHANNEL_LOGIN = os.environ.get("TWITCH_CHANNEL", "christitustech")
 LIVESTREAMS   = Path(__file__).parent.parent / "data" / "livestreams.json"
+HTTP = create_retry_session()
 
 # How close (in seconds) the Twitch VOD start must be to the YouTube publishedAt
 MATCH_WINDOW_SEC = 10800   # ±3 hours — accounts for stream-start vs YouTube publish delay
@@ -31,7 +32,7 @@ MATCH_WINDOW_SEC = 10800   # ±3 hours — accounts for stream-start vs YouTube 
 # ── Twitch auth ───────────────────────────────────────────────────────────────
 
 def get_app_token() -> str:
-    resp = requests.post(
+    resp = HTTP.post(
         "https://id.twitch.tv/oauth2/token",
         data={
             "client_id":     CLIENT_ID,
@@ -54,7 +55,7 @@ def twitch_headers(token: str) -> dict:
 # ── Twitch API helpers ────────────────────────────────────────────────────────
 
 def get_user_id(headers: dict, login: str) -> str:
-    resp = requests.get(
+    resp = HTTP.get(
         "https://api.twitch.tv/helix/users",
         params={"login": login},
         headers=headers,
@@ -92,7 +93,7 @@ def fetch_vods(headers: dict, user_id: str, max_vods: int = 200) -> list[dict]:
         params: dict = {"user_id": user_id, "type": "archive", "first": 100}
         if cursor:
             params["after"] = cursor
-        resp = requests.get(
+        resp = HTTP.get(
             "https://api.twitch.tv/helix/videos",
             params=params,
             headers=headers,

--- a/tests/python/test_http_client.py
+++ b/tests/python/test_http_client.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from urllib3.exceptions import MaxRetryError, ProtocolError
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from http_client import (  # noqa: E402
+    RETRY_COUNT,
+    RETRYABLE_STATUS_CODES,
+    build_retry_policy,
+    create_retry_session,
+)
+
+
+class RetryPolicyTests(unittest.TestCase):
+    def test_mounts_the_same_bounded_policy_for_http_and_https(self) -> None:
+        session = create_retry_session()
+
+        for prefix in ("http://", "https://"):
+            retry = session.get_adapter(prefix).max_retries
+            self.assertEqual(retry.total, RETRY_COUNT)
+            self.assertEqual(retry.connect, RETRY_COUNT)
+            self.assertEqual(retry.read, RETRY_COUNT)
+            self.assertEqual(retry.status, RETRY_COUNT)
+            self.assertEqual(retry.other, 0)
+            self.assertEqual(retry.backoff_max, 30.0)
+            self.assertEqual(retry.retry_after_max, 60)
+            self.assertTrue(retry.respect_retry_after_header)
+
+    def test_retries_only_transient_statuses_for_get_and_token_post(self) -> None:
+        retry = build_retry_policy()
+
+        for status in RETRYABLE_STATUS_CODES:
+            self.assertTrue(retry.is_retry("GET", status))
+            self.assertTrue(retry.is_retry("POST", status))
+        for status in (400, 401, 403, 404):
+            self.assertFalse(retry.is_retry("GET", status))
+            self.assertFalse(retry.is_retry("POST", status))
+
+    def test_retry_after_is_honored_but_bounded(self) -> None:
+        retry = build_retry_policy()
+        response = Mock(headers={"Retry-After": "120"})
+
+        self.assertEqual(retry.get_retry_after(response), 60)
+
+    def test_connection_reset_is_retried_then_fails_closed_when_exhausted(self) -> None:
+        retry = build_retry_policy()
+        error = ProtocolError(
+            "Connection aborted.",
+            ConnectionResetError(104, "Connection reset by peer"),
+        )
+
+        for remaining in range(RETRY_COUNT - 1, -1, -1):
+            retry = retry.increment(method="GET", url="/playlistItems", error=error)
+            self.assertEqual(retry.total, remaining)
+            self.assertEqual(retry.read, remaining)
+
+        with self.assertRaises(MaxRetryError):
+            retry.increment(method="GET", url="/playlistItems", error=error)
+
+
+class YouTubeCredentialTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location(
+            "fetch_livestreams_test_module",
+            SCRIPTS / "fetch-livestreams.py",
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load fetch-livestreams.py")
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    def test_api_key_uses_header_and_never_query_parameters(self) -> None:
+        secret = "test-secret-do-not-log"
+        response = Mock(status_code=200)
+        response.json.return_value = {"items": []}
+
+        with (
+            patch.object(self.module, "API_KEY", secret),
+            patch.object(self.module.HTTP, "get", return_value=response) as get,
+        ):
+            self.assertEqual(self.module.fetch_playlist_items(), [])
+
+        _, kwargs = get.call_args
+        self.assertNotIn("key", kwargs["params"])
+        self.assertEqual(kwargs["headers"], {"X-Goog-Api-Key": secret})
+        self.assertNotIn(secret, get.call_args.args[0])
+        response.raise_for_status.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/workflow-contract.test.js
+++ b/tests/unit/workflow-contract.test.js
@@ -193,21 +193,20 @@ describe("workflow contracts", () => {
     expect(ci.on.push.branches).toEqual(["master"]);
     expect(ci.on.workflow_dispatch).toBeUndefined();
     expect(ci.jobs["validate-dispatch"]).toBeUndefined();
+    const automationSteps = ci.jobs["automation-tests"].steps;
+    expect(automationSteps.map((step) => step.run)).toContain(
+      'python -m unittest discover -s tests/python -p "test_*.py" -v',
+    );
+    expect(JSON.stringify(automationSteps)).toContain(
+      "requirements-automation.txt",
+    );
+    expect(JSON.stringify(automationSteps)).toContain("--require-hashes");
   });
 
   it("uses an absolute TwitchDownloader executable path", async () => {
-    const result = spawnSync(
-      "python",
-      [
-        "-c",
-        "import runpy; print(runpy.run_path('scripts/download-chat-replays.py')['DOWNLOADER'])",
-      ],
-      { encoding: "utf8" },
-    );
-    expect(result.status, result.stderr).toBe(0);
-    expect(path.isAbsolute(result.stdout.trim())).toBe(true);
-    expect(result.stdout.trim()).toBe(
-      path.join(process.cwd(), "TwitchDownloaderCLI"),
+    const source = await readFile("scripts/download-chat-replays.py", "utf8");
+    expect(source).toMatch(
+      /DOWNLOADER\s*=\s*Path\(__file__\)\.resolve\(\)\.parent\.parent\s*\/\s*"TwitchDownloaderCLI"/,
     );
   });
 


### PR DESCRIPTION
## Summary

- retry transient YouTube and Twitch API failures with a shared bounded `requests` session
- retry connection/read failures and HTTP 408, 429, 500, 502, 503, and 504 with exponential backoff and bounded `Retry-After`
- keep permanent 4xx responses fail-fast
- send the YouTube API key in `X-Goog-Api-Key` instead of the request URL
- add deterministic Python regression tests and a dedicated Python 3.12 CI job
- document the Python dependency and validation setup

## Failure diagnosed

The failed deployment workflow ended on the first YouTube request after a TLS connection reset. The request had no retry policy, so downstream data/publish jobs were skipped. Production remained available, but the livestream data deployment did not complete.

Incident: Closes #291
Failed run: https://github.com/ChrisTitusTech/website/actions/runs/32656987534

## Validation completed

- Python 3.12 retry regression suite: 5 passed
- JavaScript/unit suite on Linux-normalized checkout: 64 passed
- formatting and Markdown lint on Linux-normalized checkout: passed
- Astro check/build: 0 diagnostics; 1,309 pages built
- repeatability hash: `094238ea092622bf117dfcf4a49afe106fa4e94417b05ee2bb19cf097978bedc`
- route validation: 1,183 contract routes, 968 baseline static files, 314 search entries
- Chromium/Firefox/mobile browser suite: 71 passed, 4 expected skips
- manual invalid-key request: Google accepted the header location and returned 400; the sentinel key was absent from the URL
- CodeRabbit review: 0 issues after two clean-checkout CI findings were fixed

## Handoff / remaining gates

- GitHub CI on commit `92a7f9e` is the authoritative Linux WebKit and Lighthouse gate. Native Windows WebKit had two pre-existing platform-specific assertion failures, and Windows Lighthouse hit an `EPERM` error while deleting Chrome's temporary profile after the audit.
- Two independent final-diff agent reviews and unresolved PR-thread inspection remain before merge.
- After merge, manually dispatch `update-livestreams.yml` and verify all four jobs, the monitor workflow, issue closure, and production health.
- The TwitchDownloaderCLI chat-download subprocess is intentionally outside this focused HTTP API retry change.