### PR TITLE
Add hover and focus states to code-block Copy button

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,6 +23,7 @@
   --accent-strong: #8addf8;
   --accent-ink: #04141c;
   --border: #2d4658;
+  --code-copy-hover-bg: #1c3140;
   --shadow: 0 10px 30px rgb(0 0 0 / 24%);
   --radius: 2px;
   --max: 1180px;
@@ -413,7 +414,7 @@ pre {
 .code-copy:hover,
 .code-copy:focus-visible {
   border-color: var(--accent);
-  background: #1c3140;
+  background: var(--code-copy-hover-bg);
 }
 .table-scroll {
   overflow-x: auto;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -406,6 +406,14 @@ pre {
   border-radius: var(--radius);
   padding: 0.2rem 0.45rem;
   cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+.code-copy:hover,
+.code-copy:focus-visible {
+  border-color: var(--accent);
+  background: #1c3140;
 }
 .table-scroll {
   overflow-x: auto;


### PR DESCRIPTION

This pull request introduces improvements to the styling of code copy buttons and code blocks in the global CSS. The main focus is on enhancing user experience by providing visual feedback on hover and focus states.

**Styling enhancements for code copy functionality:**

* Added a new CSS variable `--code-copy-hover-bg` for customizing the background color of code copy buttons on hover.
* Updated `.code-copy` and `.code-copy:focus-visible` selectors to change border color and background on hover/focus, and added a smooth transition for background and border color changes.