### PR TITLE
Replace navbar menu button text with hamburger icon on mobile

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -115,7 +115,7 @@ const structuredData = JSON.stringify({
     <header class="site-header">
       <nav class="nav container" aria-label="Primary navigation">
         <a class="nav-logo" href="/" aria-label="Chris Titus Tech home"><img src="/images/navlogo.webp" width="248" height="50" alt="Chris Titus Tech" /></a>
-        <button class="menu-button icon-button" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-links">Menu</button>
+        <button class="menu-button icon-button" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-links"><span class="menu-icon" aria-hidden="true"></span><span class="sr-only">Menu</span></button>
         <div class="nav-links" id="primary-links" data-menu>
           <a href="/posts/">Articles</a><a href="/downloads/">Downloads</a><a href="https://forum.christitus.com/">Forums</a><a href="/live-streams/">Live</a><a href="/newsletter/">Newsletter</a><a href="/categories/">Topics</a><a href="/search/">Search</a>
           <button class="icon-button" type="button" data-theme-toggle aria-label="Switch to light theme"><span aria-hidden="true" data-theme-icon>☀</span><span class="sr-only">Change color theme</span></button>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -151,6 +151,14 @@ input {
   display: none;
   margin-left: auto;
 }
+.menu-icon::before {
+  content: "\2630";
+  font-size: 1.1em;
+  line-height: 1;
+}
+.menu-button[aria-expanded="true"] .menu-icon::before {
+  content: "\2715";
+}
 .icon-button,
 .primary-button {
   border: 1px solid var(--border);


### PR DESCRIPTION
This pull request improves the accessibility and user experience of the main navigation menu button by updating its HTML structure and adding visual indicators for its state. The changes also introduce CSS for a menu icon that toggles between a hamburger (menu) icon and a close (X) icon based on the menu’s open state.

**Navigation Accessibility and Visual Improvements:**

* Updated the menu button in `BaseLayout.astro` to include a visually hidden label (`sr-only`) for screen readers and a `span` with the `menu-icon` class for displaying the icon.
* Added CSS in `global.css` to display a hamburger icon (`☰`) by default and switch to a close icon (`✕`) when the menu is open (`aria-expanded="true"`).