### PR TITLE
Enhance pagination layout and functionality across listings

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -3,4 +3,4 @@ interface Props { page: number; pages: number; base: string }
 const { page, pages, base } = Astro.props;
 const route = (value: number) => value === 1 ? base : `${base}page/${value}/`;
 ---
-{pages > 1 && <nav class="pagination" aria-label="Pagination"><span>{page > 1 && <a rel="prev" href={route(page - 1)}>← Newer</a>}</span><span>Page {page} of {pages}</span><span>{page < pages && <a rel="next" href={route(page + 1)}>Older →</a>}</span></nav>}
+{pages > 1 && <nav class="pagination" aria-label="Pagination"><span class="pagination-slot">{page > 1 && <a class="pagination-box" rel="prev" href={route(page - 1)}>← Newer</a>}</span><span class="pagination-box pagination-status">Page {page} of {pages}</span><span class="pagination-slot">{page < pages && <a class="pagination-box" rel="next" href={route(page + 1)}>Older →</a>}</span></nav>}

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -2,5 +2,41 @@
 interface Props { page: number; pages: number; base: string }
 const { page, pages, base } = Astro.props;
 const route = (value: number) => value === 1 ? base : `${base}page/${value}/`;
+
+type Item = number | "ellipsis";
+
+function pageItems(current: number, total: number): Item[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+  const items: Item[] = [1];
+  const left = Math.max(current - 1, 3);
+  const right = Math.min(current + 1, total - 2);
+  if (left > 3) items.push("ellipsis");
+  else if (left === 3) items.push(2);
+  for (let i = left; i <= right; i++) items.push(i);
+  if (right < total - 2) items.push("ellipsis");
+  else if (right === total - 2) items.push(total - 1);
+  items.push(total);
+  return items;
+}
+
+const items = pageItems(page, pages);
 ---
-{pages > 1 && <nav class="pagination" aria-label="Pagination"><span class="pagination-slot">{page > 1 && <a class="pagination-box" rel="prev" href={route(page - 1)}>← Newer</a>}</span><span class="pagination-box pagination-status">Page {page} of {pages}</span><span class="pagination-slot">{page < pages && <a class="pagination-box" rel="next" href={route(page + 1)}>Older →</a>}</span></nav>}
+{pages > 1 && (
+  <nav class="pagination" aria-label="Pagination">
+    {page > 1
+      ? <a class="pagination-box pagination-edge" rel="prev" href={route(page - 1)}>← Newer</a>
+      : <span class="pagination-box pagination-edge is-disabled" aria-disabled="true">← Newer</span>}
+    <span class="pagination-numbers">
+      {items.map((item) =>
+        item === "ellipsis"
+          ? <span class="pagination-ellipsis">…</span>
+          : item === page
+            ? <span class="pagination-box is-current" aria-current="page">{item}</span>
+            : <a class="pagination-box" href={route(item)}>{item}</a>
+      )}
+    </span>
+    {page < pages
+      ? <a class="pagination-box pagination-edge" rel="next" href={route(page + 1)}>Older →</a>
+      : <span class="pagination-box pagination-edge is-disabled" aria-disabled="true">Older →</span>}
+  </nav>
+)}

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -5,17 +5,29 @@ const route = (value: number) => value === 1 ? base : `${base}page/${value}/`;
 
 type Item = number | "ellipsis";
 
+const WINDOW = 5;
+
 function pageItems(current: number, total: number): Item[] {
-  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
-  const items: Item[] = [1];
-  const left = Math.max(current - 1, 3);
-  const right = Math.min(current + 1, total - 2);
-  if (left > 3) items.push("ellipsis");
-  else if (left === 3) items.push(2);
-  for (let i = left; i <= right; i++) items.push(i);
-  if (right < total - 2) items.push("ellipsis");
-  else if (right === total - 2) items.push(total - 1);
-  items.push(total);
+  if (total <= WINDOW + 2) return Array.from({ length: total }, (_, i) => i + 1);
+  const half = Math.floor(WINDOW / 2);
+  let start: number;
+  let end: number;
+  if (current <= half + 1) {
+    start = 1;
+    end = WINDOW;
+  } else if (current >= total - half) {
+    start = total - WINDOW + 1;
+    end = total;
+  } else {
+    start = current - half;
+    end = current + half;
+  }
+  const items: Item[] = [];
+  if (start > 1) items.push(1);
+  if (start > 2) items.push("ellipsis");
+  for (let i = start; i <= end; i++) items.push(i);
+  if (end < total - 1) items.push("ellipsis");
+  if (end < total) items.push(total);
   return items;
 }
 

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -6,7 +6,7 @@
   "author": "Chris Titus",
   "accent": "#47c4f1",
   "timeZone": "America/Chicago",
-  "postsPerPage": 10,
+  "postsPerPage": 12,
   "categories": [
     "Android",
     "ChromeOS",

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -114,7 +114,7 @@ export function homepagePosts(posts: Post[]): Post[] {
   );
 }
 
-export function relatedPosts(current: Post, posts: Post[], limit = 5): Post[] {
+export function relatedPosts(current: Post, posts: Post[], limit = 6): Post[] {
   return posts
     .filter((post) => post.data.url !== current.data.url)
     .map((post) => ({

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -561,29 +561,53 @@ td {
   gap: 0.75rem;
   margin-top: 1.75rem;
 }
-.pagination-slot {
-  flex: 1;
+.pagination-numbers {
   display: flex;
-}
-.pagination-slot:last-child {
-  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 .pagination-box {
   display: inline-flex;
   align-items: center;
-  padding: 0.4rem 0.85rem;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--surface) 80%, transparent);
   border-radius: var(--radius);
   text-decoration: none;
   white-space: nowrap;
+  color: var(--text);
 }
 a.pagination-box:hover {
-  border-color: var(--accent, var(--border));
+  border-color: var(--accent);
 }
-.pagination-status {
+.pagination-box.is-current {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+.pagination-box.pagination-edge {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-weight: 700;
+}
+a.pagination-box.pagination-edge:hover {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+.pagination-box.is-disabled {
+  opacity: 0.4;
+  background: var(--surface);
+  border-color: var(--border);
   color: var(--muted);
-  font-size: 0.9rem;
+}
+.pagination-ellipsis {
+  color: var(--muted);
+  padding: 0 0.15rem;
 }
 .stream-feature {
   display: grid;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -557,8 +557,8 @@ td {
 .pagination {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  justify-content: center;
+  gap: 1rem;
   margin-top: 1.75rem;
 }
 .pagination-numbers {
@@ -983,7 +983,8 @@ a.pagination-box.pagination-edge:hover {
     flex-direction: column;
   }
   .pagination {
-    align-items: flex-start;
+    flex-wrap: wrap;
+    justify-content: center;
     font-size: 0.9rem;
   }
   .heading-link {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -594,6 +594,7 @@ a.pagination-box:hover {
   background: var(--accent);
   color: var(--accent-ink);
   font-weight: 700;
+  border-radius: 8px;
 }
 a.pagination-box.pagination-edge:hover {
   background: var(--accent-strong);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -561,6 +561,30 @@ td {
   gap: 0.75rem;
   margin-top: 1.75rem;
 }
+.pagination-slot {
+  flex: 1;
+  display: flex;
+}
+.pagination-slot:last-child {
+  justify-content: flex-end;
+}
+.pagination-box {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  border-radius: var(--radius);
+  text-decoration: none;
+  white-space: nowrap;
+}
+a.pagination-box:hover {
+  border-color: var(--accent, var(--border));
+}
+.pagination-status {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
 .stream-feature {
   display: grid;
   grid-template-columns: minmax(0, 1.5fr) minmax(240px, 0.7fr);

--- a/tests/browser/site.spec.ts
+++ b/tests/browser/site.spec.ts
@@ -298,8 +298,8 @@ test("taxonomy and head pagination expose complete navigation", async ({
     page.locator('link[type="application/rss+xml"]'),
   ).toHaveAttribute("href", "https://christitus.com/categories/index.xml");
   await expect(
-    page.getByRole("navigation", { name: "Pagination" }),
-  ).toContainText("Page 1 of 2");
+    page.getByRole("navigation", { name: "Pagination" }).locator(".is-current"),
+  ).toHaveText("1");
   await expect(page.getByRole("link", { name: /older/i })).toHaveAttribute(
     "href",
     "/categories/page/2/",

--- a/tests/unit/scaffolder.test.js
+++ b/tests/unit/scaffolder.test.js
@@ -287,7 +287,7 @@ describe("post scaffolder", () => {
 
   it("induces collection pagination at the page boundary", async () => {
     const root = await fixture();
-    for (let index = 0; index < 10; index += 1) {
+    for (let index = 0; index < site.postsPerPage; index += 1) {
       await writeFile(
         path.join(root, "src/content/posts", `post-${index}.md`),
         `---\ntitle: Post ${index}\ndate: "2026-08-01"\nurl: /post-${index}/\ncategories: [Linux]\ntags: []\n---\n`,


### PR DESCRIPTION
This pull request significantly improves the pagination component, updates pagination styling, and adjusts some content and test configurations. The main focus is on enhancing pagination usability and appearance, with supporting changes to ensure consistency across the codebase.

**Pagination Component Improvements:**

* Refactored `Pagination.astro` to show a windowed set of page numbers with ellipses for skipped ranges, and improved accessibility and navigation for previous/next controls.

**Styling Updates:**

* Redesigned pagination styles in `global.css` for better layout, clearer active/disabled states, and improved responsiveness.
* Adjusted responsive behavior for the pagination component to wrap and center items on smaller screens.

**Content and Test Adjustments:**

* Increased the default number of posts per page from 10 to 12 in `site.json` for improved content density.
* Updated tests and utility functions to align with the new pagination logic and posts per page setting, ensuring correct behavior and coverage. [[1]](diffhunk://#diff-840da7bd329a81f418565c7f365966151b51e8728351bee8bb506d9f3c6cea53L301-R302) [[2]](diffhunk://#diff-c45a7ecccda661878b0580cdde2531b69278487d98df7606cfa82641cd8e3f79L290-R290) [[3]](diffhunk://#diff-ae8ca0bcbb2bbe33c0d794273257a6d2e1b9c1f88ef5ae8b5d6aa48bb1377a01L117-R117)